### PR TITLE
Bug with int64_max not being defined in some cases

### DIFF
--- a/src/AddingJson.cc
+++ b/src/AddingJson.cc
@@ -2,6 +2,10 @@
 
 #include "config.h"
 
+#ifndef __STDC_LIMIT_MACROS
+#define __STDC_LIMIT_MACROS
+#endif
+
 #include <sstream>
 #include <errno.h>
 #include <math.h>


### PR DESCRIPTION
Sync upstream
